### PR TITLE
feat: 投稿・編集時に住所から緯度経度を取得して保存

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -2,16 +2,23 @@ import prisma from "@/lib/prisma";
 export async function POST(req: Request) {
   try {
     const {title,address,explanation } = await req.json();
-
-    
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY
+    const encodedAddress = encodeURIComponent(address);
+    const res = await fetch(`https://geocode.googleapis.com/v4/geocode/address/${encodedAddress}?key=${apiKey}`)
+    const geocodeData = await res.json();
+        if (!geocodeData.results?.[0]) {
+          return Response.json({ error: "住所から位置情報を取得できませんでした。住所を見直してください。" }, { status: 400 })
+        }
+    const location = geocodeData.results[0].location
     await prisma.sanctuaries.create({
       data: {
         title,
         address,
         explanation,
+        latitude: location.latitude,
+        longitude: location.longitude
       },
     });
-
     return Response.json({ message: "聖地が登録されました" });
   } catch (error) {
     return Response.json(
@@ -24,12 +31,22 @@ export async function POST(req: Request) {
 export async function PATCH(req: Request) {
   try{
     const { id, title, address, explanation } = await req.json();
+        const apiKey = process.env.GOOGLE_MAPS_API_KEY
+    const encodedAddress = encodeURIComponent(address);
+    const res = await fetch(`https://geocode.googleapis.com/v4/geocode/address/${encodedAddress}?key=${apiKey}`)
+    const geocodeData = await res.json();
+        if (!geocodeData.results?.[0]) {
+          return Response.json({ error: "住所から位置情報を取得できませんでした。住所を見直してください。" }, { status: 400 })
+        }
+    const location = geocodeData.results[0].location
 
     await prisma.sanctuaries.update({
             data: {
                 title,
                 explanation,
-                address
+                address,
+                latitude: location.latitude,
+                longitude: location.longitude
             },
             where: {
                 id: id


### PR DESCRIPTION
投稿・編集時に住所から緯度経度を取得し、`latitude` / `longitude` に保存する処理を追加しました。  
取得に失敗した場合は保存せず、エラーを返すようにしています。