### PR TITLE
Feature/places map markers

### DIFF
--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -26,8 +26,8 @@ export default function PlacesMap({ posts }: PlacesMapProps) {
     <APIProvider apiKey={mapKey}>
     <Map
         style={{width: '100%', height: '100%'}}
-        defaultCenter={{lat: 22.54992, lng: 0}}
-        defaultZoom={3}
+        defaultCenter={{lat:35.7056, lng: 139.7519}}
+        defaultZoom={10}
         gestureHandling='greedy'
         disableDefaultUI
     />

--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -1,8 +1,24 @@
 "use client";
-import {APIProvider, Map} from '@vis.gl/react-google-maps';
+import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps'; 
+type  Post= {
+    id: number;
+    title: string
+    explanation: string
+    address: string
+    latitude: number
+    longitude: number
+}
 
-export default function PlacesMap() {
+type PlacesMapProps = {
+  posts: Post[];
+};
+
+export default function PlacesMap({ posts }: PlacesMapProps) {
     const mapKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+    console.log(posts.length)
+    console.log(posts[17]['title'])
+    console.log(posts[17]['latitude'])
+    console.log(posts[17]['longitude'])
     if (!mapKey) {
           return <p>APIキーがありません</p>
         }
@@ -15,6 +31,7 @@ export default function PlacesMap() {
         gestureHandling='greedy'
         disableDefaultUI
     />
+      <Marker position={{lat: posts[17].latitude,lng: posts[17].longitude}} />
     </APIProvider>
     )
 }

--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps'; 
+import { useState } from 'react';
 type  Post= {
     id: number;
     title: string
@@ -12,13 +13,9 @@ type  Post= {
 type PlacesMapProps = {
   posts: Post[];
 };
-
 export default function PlacesMap({ posts }: PlacesMapProps) {
+    const [selectedPost, setSelectedPost] = useState<Post | null>(null);
     const mapKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
-    console.log(posts.length)
-    console.log(posts[17]['title'])
-    console.log(posts[17]['latitude'])
-    console.log(posts[17]['longitude'])
     if (!mapKey) {
           return <p>APIキーがありません</p>
         }
@@ -27,6 +24,16 @@ export default function PlacesMap({ posts }: PlacesMapProps) {
        return post.latitude != null && post.longitude != null
      });
     return (
+    <div>
+      {selectedPost&& <div className="bg-gray-100 p-6 rounded-lg">
+                <h2 className="text-lg text-gray-900 font-medium title-font mb-4">タイトル: {selectedPost.title}</h2>
+                <h2 className="text-lg text-gray-900 font-medium title-font mb-4">住所: {selectedPost.address}</h2>
+                <p className="leading-relaxed text-base">説明: {selectedPost.explanation}</p>
+              
+                {/* <EditButton href={`/places/${selectedPost.id}/edit`} /> */}
+            </div>}
+    
+    <div className="w-full h-[600px] relative m-4">
     <APIProvider apiKey={mapKey}>
     <Map
         style={{width: '100%', height: '100%'}}
@@ -35,10 +42,12 @@ export default function PlacesMap({ posts }: PlacesMapProps) {
         gestureHandling='greedy'
         disableDefaultUI
          >
-    {mapPosts.map((post) => { return (<Marker position={{lat: post.latitude,lng: post.longitude}} key={post.id}>
+    {mapPosts.map((post) => { return (<Marker position={{lat: post.latitude,lng: post.longitude}} key={post.id} onClick={() => setSelectedPost(post)}>
             </Marker>) })}
     </Map>
     </APIProvider>
+    </div>
+    </div>
     )
 }
 

--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -6,8 +6,8 @@ type  Post= {
     title: string
     explanation: string
     address: string
-    latitude: number | null
-    longitude: number | null
+    latitude: number
+    longitude: number
 }
 
 type PlacesMapProps = {

--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -22,6 +22,10 @@ export default function PlacesMap({ posts }: PlacesMapProps) {
     if (!mapKey) {
           return <p>APIキーがありません</p>
         }
+
+    const mapPosts = posts.filter((post) => {
+       return post.latitude != null && post.longitude != null
+     });
     return (
     <APIProvider apiKey={mapKey}>
     <Map
@@ -30,8 +34,10 @@ export default function PlacesMap({ posts }: PlacesMapProps) {
         defaultZoom={10}
         gestureHandling='greedy'
         disableDefaultUI
-    />
-      <Marker position={{lat: posts[17].latitude,lng: posts[17].longitude}} />
+         >
+    {mapPosts.map((post) => { return (<Marker position={{lat: post.latitude,lng: post.longitude}} key={post.id}>
+            </Marker>) })}
+    </Map>
     </APIProvider>
     )
 }

--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -2,12 +2,12 @@
 import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps'; 
 import { useState } from 'react';
 type  Post= {
-    id: number;
+    id: string
     title: string
     explanation: string
     address: string
-    latitude: number
-    longitude: number
+    latitude: number | null
+    longitude: number | null
 }
 
 type PlacesMapProps = {

--- a/app/places/_components/PlacesMapClient.tsx
+++ b/app/places/_components/PlacesMapClient.tsx
@@ -2,12 +2,12 @@
 import dynamic from "next/dynamic"
 
 type Post = {
-  id: number;
+  id: string
   title: string;
   explanation: string;
   address: string;
-  latitude: number;
-  longitude: number;
+  latitude: number | null
+  longitude: number | null
 };
 
 type PlacesMapClientProps = {

--- a/app/places/_components/PlacesMapClient.tsx
+++ b/app/places/_components/PlacesMapClient.tsx
@@ -1,13 +1,26 @@
 "use client";
 import dynamic from "next/dynamic"
 
+type Post = {
+  id: number;
+  title: string;
+  explanation: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+};
+
+type PlacesMapClientProps = {
+  posts: Post[];
+};
+
 const PlacesMap = dynamic(
     () => import('./PlacesMap'),
     {ssr: false}
 )
-export default function PlacesMapClient() {
+export default function PlacesMapClient({ posts }: PlacesMapClientProps) {
     return ( 
-        <PlacesMap />
+        <PlacesMap posts={posts}/>
     )
 }
 

--- a/app/places/_components/PlacesMapClient.tsx
+++ b/app/places/_components/PlacesMapClient.tsx
@@ -6,8 +6,8 @@ type Post = {
   title: string;
   explanation: string;
   address: string;
-  latitude: number | null
-  longitude: number | null
+  latitude: number 
+  longitude: number
 };
 
 type PlacesMapClientProps = {

--- a/app/places/index/page.tsx
+++ b/app/places/index/page.tsx
@@ -23,7 +23,7 @@ export default async function PlacesIndexPage() {
         </div>) })}
     </div>
     <div className="w-3/5 bg-pink-100 h-[600px] relative m-4">
-       <PlacesMapClient />
+       <PlacesMapClient posts={posts} />
       </div>
     </div>
     </div>

--- a/prisma/migrations/20260420150820_make_latitude_longitude_required/migration.sql
+++ b/prisma/migrations/20260420150820_make_latitude_longitude_required/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Made the column `latitude` on table `Sanctuaries` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `longitude` on table `Sanctuaries` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Sanctuaries" ALTER COLUMN "latitude" SET NOT NULL,
+ALTER COLUMN "longitude" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,8 +64,8 @@ model Sanctuaries {
   title        String
   address      String
   explanation  String
-  latitude     Float?
-  longitude    Float?
+  latitude     Float
+  longitude    Float
   
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt


### PR DESCRIPTION
- ピンをクリックしたときに、タイトル・住所・説明を表示できるようにした
- PlacesMapClient と PlacesMap に posts を props で渡せるようにした
- Post と PlacesMapProps の型を整理した
- 地図に使える投稿だけ残すために、緯度経度がある投稿を絞り込んだ
- Google Maps 上に聖地を複数ピン表示できるようにした
- 地図の初期表示位置を東京付近に調整した
- Marker にクリック処理を付けた
- クリックしたピンの聖地情報を selectedPost で保持できるようにした
