### PR TITLE
feat: 投稿ページに地図を表示

### DIFF
--- a/app/places/index/page.tsx
+++ b/app/places/index/page.tsx
@@ -1,7 +1,6 @@
 import EditButton from '../../_components/EditButton'
 import prisma from "@/lib/prisma";
 import Link from "next/link";
-import Image from "next/image";
 import PlacesMapClient from '../_components/PlacesMapClient'
 
 export default async function PlacesIndexPage() {
@@ -9,7 +8,7 @@ export default async function PlacesIndexPage() {
     return (
     <div>
         <h1>場所一覧</h1>
-    <div className="flex">
+    <div className="flex ">
     <div className="overflow-y-auto m-4 h-[600px]">
         {posts.map((post) => { return (<div className=" p-4" key={post.id}>
             <div className="bg-gray-100 p-6 rounded-lg">
@@ -22,7 +21,7 @@ export default async function PlacesIndexPage() {
             </div>
         </div>) })}
     </div>
-    <div className="w-3/5 bg-pink-100 h-[600px] relative m-4">
+    <div className="w-3/5 h-[600px] relative ">
        <PlacesMapClient posts={posts} />
       </div>
     </div>

--- a/app/places/new/_components/NewPlaceForm.tsx
+++ b/app/places/new/_components/NewPlaceForm.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation";
+import PostButton from "@/app/_components/PostButton";
+type FormValues = {
+    title: string
+    explanation: string
+    address: string
+}
+export default function NewPlaceForm() {
+  const router = useRouter();
+  const { register, handleSubmit} = useForm<FormValues>({})
+  const submitNewPlace = async(data: FormValues): Promise<void> => {
+    try {
+      const res = await fetch("/api/places", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title:data.title, address:data.address, explanation:data.explanation }),
+      })
+    
+    if (res.ok) {
+        router.push("/places/index");
+      }}
+    catch (error) {
+      console.error("投稿失敗:", error);
+   }}
+  return (
+    <form className="px-6 mt-4 mb-4 w-full" onSubmit={handleSubmit(submitNewPlace)}>
+            <h1 className="text-gray-800 text-2xl font-bold mb-4 ">聖地投稿フォーム</h1>
+            <p className="text-gray-800">タイトル</p>
+            <input {...register('title')} className="mr-6  sm:mr-0  text-black bg-blue-100" />
+            <p className="text-gray-800">説明</p>
+            <textarea
+              {...register('explanation')}
+              className="mr-6 sm:mr-0  text-black bg-blue-100 h-[100px]"
+            />
+            <p className="text-gray-800">住所</p>
+            <input type="text" {...register('address')} className="mr-6  sm:mr-0  text-black bg-blue-100" />
+            <p>
+              <PostButton/>
+            </p>
+    </form>
+  );
+}
+

--- a/app/places/new/page.tsx
+++ b/app/places/new/page.tsx
@@ -1,57 +1,18 @@
-'use client'
-import PostButton from "../../_components/PostButton";
-import Image from "next/image";
-import { useForm } from "react-hook-form"
-import { useRouter } from "next/navigation";
-type FormValues = {
-    title: string
-    explanation: string
-    address: string
-}
-export default function PlacesNewPage() {
-  const router = useRouter();
-  const { register, handleSubmit} = useForm<FormValues>({})
-  const submitNewPlace = async(data: FormValues): Promise<void> => {
-    try {
-      const res = await fetch("/api/places", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title:data.title, address:data.address, explanation:data.explanation }),
-      })
-    
-    if (res.ok) {
-        router.push("/places/index");
-      }}
-    catch (error) {
-      console.error("投稿失敗:", error);
-   }}
+import PlacesMapClient from '../_components/PlacesMapClient'
+import NewPlaceForm from './_components/NewPlaceForm'
+import prisma from "@/lib/prisma";
+
+export default async function PlacesNewPage() {
+  const posts = await prisma.sanctuaries.findMany();
   return (
-    <div className="flex">
-      <div className="w-2/5 bg-[#020817] h-[600px] p-8">
-      <form className="px-6 mt-4 mb-4 w-full" onSubmit={handleSubmit(submitNewPlace)}>
-        <h1 className="text-white text-2xl font-bold mb-4">聖地投稿フォーム</h1>
-        <p className="text-white">タイトル</p>
-        <input {...register('title')} className="mr-6  sm:mr-0  text-black bg-white" />
-        <p className="text-white">説明</p>
-        <textarea
-          {...register('explanation')}
-          className="mr-6 sm:mr-0  text-black bg-white h-[100px]"
-        />
-        <p className="text-white">住所</p>
-        <input type="text" {...register('address')} className="mr-6  sm:mr-0  text-black bg-white" />
-        <p>
-          <PostButton />
-        </p>
-        </form>
+    <div className="flex px-10 gap-10">
+      <div className="w-2/5 h-[600px] p-8">
+        <NewPlaceForm />
       </div>
-      <div className="w-3/5 bg-pink-100 h-[600px] relative ">
-        <Image
-          className=" object-cover object-center"
-          src="/map.png"
-          alt="地図画像"
-          fill
-        />
-      </div>
-    </div>
+      <div className="w-3/5  h-[600px] relative m-4">
+             <PlacesMapClient posts={posts} />
+            </div>
+          </div>
+  
   );
 }


### PR DESCRIPTION
投稿ページで地図を出すために、フォーム処理を client component に分けて、page 側で聖地一覧を取得して地図に渡す構成に直しました。