### PR TITLE
style: 詳細ページのUIを整える

### DIFF
--- a/app/places/[placeId]/page.tsx
+++ b/app/places/[placeId]/page.tsx
@@ -1,6 +1,8 @@
 import prisma from "@/lib/prisma";
 import EditButton from '../../_components/EditButton'
 import { format } from "date-fns"
+import Link from "next/link";
+import { ArrowLeft, MapPin,Calendar,NotebookText } from "lucide-react"
 
 interface PlacesDetailPageProps {
   params: {
@@ -17,19 +19,21 @@ if (!post) {
     return <div className="text-center text-sm my-10">聖地がありません</div>
   }
   return (
-    <div>
-      <div className="flex flex-wrap -m-4">
-        <div className="xl:w-1/4 md:w-1/2 p-4" >
-            <div className="bg-gray-100 p-6 rounded-lg">
-                <h2 className="text-lg text-gray-900 font-medium title-font mb-4">タイトル: {post.title}</h2>
-                <h2 className="text-lg text-gray-900 font-medium title-font mb-4">住所: {post.address}</h2>
-                <p className="leading-relaxed text-base">説明: {post.explanation}</p>
-                <p className="leading-relaxed text-base">作成日: {format(new Date(post.createdAt), "yyyy/MM/dd")}</p>
-
+    <div className="bg-gray-50 py-8 px-6 min-h-screen">
+      <div className="max-w-3xl mx-auto">
+      <Link href="/places/index" className="text-sm text-gray-500 mb-4 items-center inline-flex gap-1"><ArrowLeft size={16} /> 聖地一覧に戻る</Link>
+            <div className="bg-white p-6 rounded-xl shadow-md">
+                <h2 className="text-xl text-gray-900 title-font mb-4 pb-2 font-bold border-b border-gray-200">{post.title}</h2>
+                <div className="border-b border-gray-200">
+                <p className="text-lg text-gray-900 font-medium title-font flex items-center gap-2"> <MapPin size={24} color="gray" strokeWidth={1} /> {post.address}</p>
+                <p className="leading-relaxed text-base flex items-center gap-2"> <Calendar size={24} color="gray" strokeWidth={1} /> {format(new Date(post.createdAt), "yyyy/MM/dd")}</p>
+                <p className="leading-relaxed text-base flex gap-2 pt-4 pb-4 mb-4"> <NotebookText size={24} color="gray" strokeWidth={1} /> {post.explanation}</p>
+                </div>
+                <div className="pt-4">
                 <EditButton href={`/places/${post.id}/edit`} />
+                </div>
             </div>
         </div>
-    </div>
-    </div>
+     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vis.gl/react-google-maps": "^1.8.3",
         "bcryptjs": "^3.0.3",
         "date-fns": "^4.1.0",
+        "lucide-react": "^1.16.0",
         "next": "16.1.6",
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.3",
@@ -5260,6 +5261,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vis.gl/react-google-maps": "^1.8.3",
     "bcryptjs": "^3.0.3",
     "date-fns": "^4.1.0",
+    "lucide-react": "^1.16.0",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.30",
     "react": "19.2.3",


### PR DESCRIPTION
詳細ページのUIを整えました。
中央カードレイアウトに変更し、戻るリンク・住所・作成日・説明にアイコンを追加しています。
また、タイトルを主役にした表示へ変更し、余白・区切り線・影・角丸を調整しました。