### PR TITLE
feat: 投稿画面をレスポンシブ対応

### DIFF
--- a/app/places/new/_components/NewPlaceContainer.tsx
+++ b/app/places/new/_components/NewPlaceContainer.tsx
@@ -40,16 +40,16 @@ export default function NewPlaceContainer({ posts }: NewPlaceContainerProps) {
      <>
     {/* <NewPlaceForm selectedLocation={selectedLocation} />
     <PlacesMapClient posts={posts} onLocationSelect={handleLocationSelect} /> */}
-  <div className="flex px-10 gap-10">
-    <div className="w-2/5 h-[600px] p-8">
+  <div className="flex px-4 md:px-10 gap-6 md:gap-10 flex-col md:flex-row">
+    <div className="md:w-2/5 md:h-[600px] p-8 flex flex-col gap-4 w-full order-2 md:order-1">
     <h1 className="text-gray-800 text-2xl font-bold mb-4">聖地を投稿しよう！</h1>
     <p className="text-gray-800 mb-4">地図上の好きな場所をクリックして、聖地を投稿しよう！</p>
     <p className="text-gray-800 mb-4">投稿したい場所を地図上でクリックすると、投稿フォームが表示されます。</p>
     <p className="text-gray-800 mb-4">MV、ドラマ、映画、番組のタイトル、説明を入力して、住所を確認して投稿ボタンを押してください。。</p>
     </div>
-  <div className="w-3/5 h-[600px] relative m-4 overflow-hidden">
-    <PlacesMapClient posts={posts} onLocationSelect={handleLocationSelect} />
-    {isModalOpen&& <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10"><div className="bg-white text-black rounded-2xl p-6 shadow-xl w-[400px] h-[400px]"><NewPlaceForm selectedLocation={selectedLocation} /><button onClick={closeModal}>閉じる</button></div></div>} 
+  <div className="md:w-3/5 md:h-[600px] relative overflow-hidden order-1 md:order-2 w-full h-[360px]">
+    <PlacesMapClient posts={posts} onLocationSelect={handleLocationSelect} />                                        
+    {isModalOpen&& <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10"><div className="bg-white text-black rounded-2xl p-6 shadow-xl w-[90%] max-w-[400px] max-h-[90%] overflow-y-auto"><NewPlaceForm selectedLocation={selectedLocation} /><button onClick={closeModal}>閉じる</button></div></div>} 
   </div>
 </div>
   </>

--- a/app/places/new/_components/NewPlaceForm.tsx
+++ b/app/places/new/_components/NewPlaceForm.tsx
@@ -47,20 +47,20 @@ export default function NewPlaceForm({ selectedLocation }: NewPlaceFormProps) {
       console.error("投稿失敗:", error);
    }}
   return (
-    <form className="px-6 mt-4 mb-4 w-full" onSubmit={handleSubmit(submitNewPlace)}>
-            <h1 className="text-gray-800 text-2xl font-bold mb-4 ">聖地投稿フォーム</h1>
-            <p className="text-gray-800">タイトル</p>
-            <input {...register('title')} className="mr-6  sm:mr-0  text-black bg-blue-100" />
-            <p className="text-gray-800">説明</p>
-            <textarea
-              {...register('explanation')}
-              className="mr-6 sm:mr-0  text-black bg-blue-100 h-[100px]"
-            />
-            <p className="text-gray-800">住所</p>
-            <input type="text" {...register('address')} className="mr-6  sm:mr-0  text-black bg-blue-100" />
-            <p>
-              <PostButton/>
-            </p>
+    <form className="px-6 mt-4 mb-4 w-full " onSubmit={handleSubmit(submitNewPlace)}>
+      <h1 className="text-gray-800 text-2xl font-bold mb-4 ">聖地投稿フォーム</h1>
+      <p className="text-gray-800">タイトル</p>
+      <input {...register('title')} className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3" />
+      <p className="text-gray-800">説明</p>
+      <textarea
+        {...register('explanation')}
+        className="text-black bg-blue-100 h-[100px] w-full rounded p-2 mt-1 mb-3"
+      />
+      <p className="text-gray-800">住所</p>
+      <input type="text" {...register('address')} className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3"/>
+      <p>
+        <PostButton/>
+      </p>
     </form>
   );
 }


### PR DESCRIPTION
投稿画面をスマホでは縦並びに変更
スマホでは地図を上、説明文を下に表示
投稿モーダルの幅と高さをスマホ対応
スマホでは×ボタン、PCでは閉じるボタンを表示
フォーム入力欄を横幅いっぱいに調整