### PR TITLE
feat: 認証画面とヘッダーのUIを改善

### DIFF
--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,18 +1,20 @@
 import Link from 'next/link'
+import Image from 'next/image'
 export default function Header() {
   return (
     <header className='bg-[#0EA5E9] py-4 px-4 text-white'>
       <div className="flex justify-between mx-auto max-w-6xl items-center">
-        <div><Link href="/" className="font-bold text-lg">Snow Map</Link></div>
+          <Link href="/" className="flex items-center gap-2">
+            <Image src="/logo.png" alt="ロゴ" width={32} height={32} />
+            <span className="font-bold text-lg">Snow Map</span>
+          </Link>
         <div className="flex gap-6 text-sm">
             <Link href="/places/index">聖地一覧</Link>
             <Link href="/auth/login">ログイン</Link>
             <Link href="/auth/register">新規登録</Link>
         </div>
       </div> 
-     
     </header>
-
   )
 }
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react'
 
 export default function LoginPage() {
   return (
-    <div className="md:min-h-screen bg-gray-100 flex md:items-center px-4 py-10">
+    <div className="bg-gray-100 px-4 py-10 md:min-h-screen md:flex md:items-center">
     <div className="mx-auto max-w-lg p-6 md:p-8 bg-white rounded-2xl shadow">
       <div className="mb-6 flex items-center gap-2">
         <Image src="/logo.png" alt="ロゴ" width={32} height={32} />
@@ -16,8 +16,7 @@ export default function LoginPage() {
       <Suspense fallback={<p>読み込み中...</p>}>
       <LoginForm />
       </Suspense>
-
-      <div className="mt-4 text-center">
+      <div className="mt-4 text-center text-sm">
         <span className="text-gray-600">アカウントをお持ちでない方は</span>
         <Link href="/auth/register" className="ml-1 text-blue-600 hover:underline">
           新規登録

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,22 +1,25 @@
-"use client";
-import { signIn } from "next-auth/react";
 import Link from 'next/link'
 import { RegisterForm } from './_components/RegisterForm'
+import Image from 'next/image'
 
 export default function RegisterPage() {
   return (
-     <div className="mx-auto max-w-md py-10">
+    <div className="md:min-h-screen bg-gray-100 md:flex md:items-center px-4 py-10">
+     <div className="mx-auto max-w-lg p-6 md:p-8 bg-white rounded-2xl shadow">
+        <div className="mb-6 flex items-center gap-2">
+          <Image src="/logo.png" alt="ロゴ" width={32} height={32} />
+          <p className="text-sm font-semibold text-sky-500">Snow Man Pilgrimage</p>
+        </div>
       <h1 className="mb-4 text-2xl font-bold">アカウント作成</h1>
-       <p className="mb-10 text-sm">登録をして聖地巡礼の記録を始めよう</p>
-      
+       <p className="mb-10 text-sm text-gray-600">登録をして聖地巡礼の記録を始めよう</p>
       <RegisterForm />
-
       <div className="mt-4 text-center text-sm">
         <span className="text-gray-600">既にアカウントをお持ちの方は</span>
         <Link href="/auth/login" className="ml-1 text-blue-600 hover:underline">
             ログイン
         </Link>
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## 変更内容
- ログイン画面をカード型レイアウトに変更
- 新規登録画面をログイン画面と同じデザインに統一
- 認証画面にロゴと説明文を追加
- ヘッダーにロゴを追加
- PC / スマホ表示の余白とカード幅を調整