### PR TITLE
feat: ログイン状態に応じてヘッダー表示を切り替え

### DIFF
--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,6 +1,11 @@
 import Link from 'next/link'
 import Image from 'next/image'
-export default function Header() {
+import type { Session } from "next-auth"
+
+type HeaderProps = {
+  session: Session | null
+}
+export default function Header( { session }: HeaderProps ) {
   return (
     <header className='bg-[#0EA5E9] py-4 px-4 text-white'>
       <div className="flex justify-between mx-auto max-w-6xl items-center">
@@ -10,8 +15,15 @@ export default function Header() {
           </Link>
         <div className="flex gap-6 text-sm">
             <Link href="/places/index">聖地一覧</Link>
-            <Link href="/auth/login">ログイン</Link>
-            <Link href="/auth/register">新規登録</Link>
+            <Link href="/places/new">聖地投稿</Link>
+            {session ? (
+              <Link href="/auth/logout">ログアウト</Link>
+            ) : (
+              <>
+                <Link href="/auth/login">ログイン</Link>
+                <Link href="/auth/register">新規登録</Link>
+              </>
+            )}
         </div>
       </div> 
     </header>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Footer from './_components/Footer'
 import Header from './_components/Header'
-
+import {auth} from "@/lib/auth";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -19,15 +19,16 @@ export const metadata: Metadata = {
   description: "SnowManの聖地巡礼マップ",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await auth()
   return (
     <html lang="ja">
       <body>
-        <Header/>
+        <Header session={session}/>
         {children}
         <Footer/>
       </body>


### PR DESCRIPTION
## 概要
ログイン状態に応じてヘッダー表示を切り替えられるようにしました。

## 変更内容
- ログイン中は「ログアウト」を表示
- 未ログイン時は「ログイン」「新規登録」を表示
- 「聖地一覧」「聖地投稿」はログイン状態に関係なく表示