### PR TITLE
feat: ヘッダーにハンバーガーメニューを追加

### DIFF
--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,11 +1,20 @@
+"use client"
 import Link from 'next/link'
 import Image from 'next/image'
 import type { Session } from "next-auth"
+import { useState } from 'react'
 
 type HeaderProps = {
   session: Session | null
 }
 export default function Header( { session }: HeaderProps ) {
+  const [openMenu, setOpenMenu] = useState(false)
+  const menuFunction = () => {
+    setOpenMenu((openMenu) => !openMenu);
+  }
+  const closeFunction = () => {
+  setOpenMenu(false)
+}
   return (
     <header className='bg-[#0EA5E9] py-4 px-4 text-white'>
       <div className="flex justify-between mx-auto max-w-6xl items-center">
@@ -13,7 +22,7 @@ export default function Header( { session }: HeaderProps ) {
             <Image src="/logo.png" alt="ロゴ" width={32} height={32} />
             <span className="font-bold text-lg">Snow Map</span>
           </Link>
-        <div className="flex gap-6 text-sm">
+        <div className="hidden md:flex gap-6 text-sm">
             <Link href="/places/index">聖地一覧</Link>
             <Link href="/places/new">聖地投稿</Link>
             {session ? (
@@ -25,7 +34,30 @@ export default function Header( { session }: HeaderProps ) {
               </>
             )}
         </div>
-      </div> 
+        <button className="text-xl md:hidden" onClick={menuFunction}>
+          ☰
+        </button>
+      </div>
+      <nav className={`${openMenu ? 'block' : 'hidden'} md:hidden px-4 py-4 `}>
+          <ul>
+            <li className='mt-2 text-xl '><Link href="/places/index" onClick={closeFunction}>聖地一覧</Link></li>
+            <li className='mt-2 text-xl '><Link href="/places/new" onClick={closeFunction}>聖地投稿</Link></li>
+          </ul>
+          {session ? (
+            <ul>
+            <li className='mt-2 text-xl '>
+            <Link href="/auth/logout" onClick={closeFunction}>ログアウト</Link>
+            </li>
+            </ul>
+          ) : (
+              <>
+                <ul>
+                <li className='mt-2 text-xl '><Link href="/auth/login" onClick={closeFunction}>ログイン</Link></li>
+                <li className='mt-2 text-xl '><Link href="/auth/register" onClick={closeFunction}>新規登録</Link></li>
+                </ul>
+              </>
+            )}
+        </nav> 
     </header>
   )
 }

--- a/app/auth/login/_components/LoginForm.tsx
+++ b/app/auth/login/_components/LoginForm.tsx
@@ -2,7 +2,6 @@
 
 import { signIn } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
-
 import { useState } from 'react'
 
 


### PR DESCRIPTION
## 概要
ヘッダーにハンバーガーメニューを追加しました。

## 変更内容
- スマホ表示時にハンバーガーボタンを表示
- メニューの開閉状態をuseStateで管理
- PC表示時は従来通り横並びメニューを表示
- メニュー内リンクをクリックした際にメニューを閉じるように調整
参考
[useStateを使ってハンバーガーメニューを作る](https://note.com/spark_branding_/n/naac7aae57db2)