### PR TITLE
feat: 一覧ページの編集ボタンをログイン時のみ表示する

### DIFF
--- a/app/places/index/_components/PlacesIndexContainer.tsx
+++ b/app/places/index/_components/PlacesIndexContainer.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import EditButton from '../../../_components/EditButton'
 import Link from "next/link";
 import PlacesMapClient from '../../_components/PlacesMapClient'
-
+import type { Session } from "next-auth"
 
 type PostWithLocation = {
   id: string
@@ -18,6 +18,7 @@ type PostWithLocation = {
 
 type PlacesIndexContainerProps = {
   posts: PostWithLocation[]
+  session: Session | null
 }
 
 type CurrentLocation = { 
@@ -38,7 +39,7 @@ const calculate = ({ post,currentLocation }: { post: PostWithLocation; currentLo
       return distance
 }
 
-export default function PlacesIndexContainer({ posts }: PlacesIndexContainerProps) {
+export default function PlacesIndexContainer({ posts, session }: PlacesIndexContainerProps) {
     const [currentLocation, setCurrentLocation] = useState<CurrentLocation | null>(null);
     const handleGetCurrentLocation = () =>{
           navigator.geolocation.getCurrentPosition(position => {
@@ -85,7 +86,7 @@ sortedPosts.sort(compare)
                 <Link className="rounded bg-gray-800 px-4 py-2 text-white" href={`/places/${post.id}`}>
                      詳細
                 </Link>
-                <EditButton href={`/places/${post.id}/edit`} />
+                {session && <EditButton href={`/places/${post.id}/edit`} />}
                 </div>
             </div>
         </div>) })}

--- a/app/places/index/page.tsx
+++ b/app/places/index/page.tsx
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import PlacesIndexContainer from './_components/PlacesIndexContainer'
+import { auth } from "@/lib/auth";
 
 type PostWithLocation = {
   id: string
@@ -13,10 +14,11 @@ type PostWithLocation = {
 }
 
 export default async function PlacesIndexPage() {
+    const session = await auth();
     const posts = await prisma.sanctuaries.findMany();
     const mapPosts = posts.filter((post) : post is PostWithLocation => { return (post.latitude !==null && post.longitude!==null)});
     return (
     
-       <PlacesIndexContainer posts={mapPosts} />
+       <PlacesIndexContainer posts={mapPosts} session={session}/>
   )
 }


### PR DESCRIPTION
未ログイン時は、一覧ページの編集ボタンを非表示にする仕様にしました。
一覧ページでは親の page.tsx で session を取得し、PlacesIndexContainer に props として渡して表示制御しています。