### PR TITLE
"fix: 地図レイアウトの調整"

### DIFF
--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -36,7 +36,7 @@ export default function PlacesMap({ posts, onLocationSelect }: PlacesMapProps) {
     return (
   
     
-    <div className="w-full h-[600px] relative m-4">
+    <div className="w-full h-full relative">
     <APIProvider apiKey={mapKey}>
     <Map
         style={{width: '100%', height: '100%'}}

--- a/app/places/index/_components/PlacesIndexContainer.tsx
+++ b/app/places/index/_components/PlacesIndexContainer.tsx
@@ -60,20 +60,19 @@ sortedPosts.sort(compare)
 }
   return (
     <div className="bg-gray-100 p-4 flex flex-col">
-        <div className="flex items-center gap-2 font-bold text-2xl mb-4">
-           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"></path><circle cx="12" cy="10" r="3"></circle></svg>
-            <h1>場所一覧</h1>
-        </div>
+      <div className="flex items-center gap-2 font-bold text-2xl mb-4">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"></path><circle cx="12" cy="10" r="3"></circle></svg>
+        <h1>場所一覧</h1>
+      </div>
     <div className="flex gap-8 flex-col md:flex-row">
-    <div className="md:w-2/5 flex flex-col gap-4 w-full order-2 md:order-1">
-
-    <div>
-     <div className="flex-col gap-2 mb-4 items-start">
+      <div className="md:w-2/5 flex flex-col gap-4 w-full order-2 md:order-1">
+        <div>
+        <div className="flex-col gap-2 mb-4 items-start">
           <button className="bg-blue-500 rounded-full text-white py-2 px-4" onClick={handleGetCurrentLocation}>現在地を取得</button>
-     </div>
-        {currentLocation && (
-    <p>現在地を取得しました</p>
-)}</div>
+        </div>
+          {currentLocation && (
+        <p>現在地を取得しました</p>
+     )}</div>
     <div className="overflow-y-auto h-[600px]">
         {sortedPosts.map((post) => { return (<div className=" p-4" key={post.id}>
             <div className="bg-white p-6 rounded-lg shadow-md">


### PR DESCRIPTION
地図コンポーネント内の m-4 が、親要素の枠内に余白を作っていたため削除しました。
また、地図側の高さを h-[600px] で固定せず h-full にして、一覧ページ側の親要素の高さに合わせるようにしました。