### PR TITLE
feat: 詳細画面に投稿者名を表示する

### DIFF
--- a/app/_components/DeleteButton.tsx
+++ b/app/_components/DeleteButton.tsx
@@ -26,7 +26,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
     <button
       type="button"
       onClick={() => submitDeletePlace()}
-      className="rounded bg-gray-300 px-4 py-2 text-gray-800"
+      className="rounded bg-red-500 px-4 py-2 text-white"
     >
       削除
     </button>

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -35,7 +35,7 @@ export default function Footer() {
         </div>
         <div>
           <h3 className="font-bold">サポート</h3>
-          <div className="space-y-2">
+          <div className="flex flex-col gap-2">
             <Link href="/terms" className="text-gray-200 hover:underline">
               利用規約
             </Link>

--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -1,5 +1,14 @@
 import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+
 export async function POST(req: Request) {
+  const session = await auth();
+  if (!session || !session.user || !session.user.id) {
+  return Response.json(
+    { error: "ログインが必要です。" },
+    { status: 401 }
+  );
+}
   try {
     const { title, address, explanation, latitude, longitude } =
       await req.json();
@@ -36,6 +45,7 @@ export async function POST(req: Request) {
         explanation,
         latitude: saveLatitude,
         longitude: saveLongitude,
+        userId: session.user.id,
       },
     });
     return Response.json({ message: "聖地が登録されました" });

--- a/app/places/[placeId]/page.tsx
+++ b/app/places/[placeId]/page.tsx
@@ -15,8 +15,10 @@ export default async function PlacesPage({ params }: PlacesDetailPageProps) {
   const { placeId } = await params;
   const post = await prisma.sanctuaries.findUnique({
     where: { id: placeId },
+    include: {
+      user: true,
+    },
   });
-
   if (!post) {
     return <div className="text-center text-sm my-10">聖地がありません</div>;
   }
@@ -55,9 +57,10 @@ export default async function PlacesPage({ params }: PlacesDetailPageProps) {
                 <p className="leading-relaxed text-base">{post.explanation}</p>
               </div>
             )}
+              <p>作成者: {post.user?.name}</p>
           </div>
           {session && (
-            <div className="pt-4">
+            <div className="pt-4 gap-3 flex">
               <EditButton href={`/places/${post.id}/edit`} />
               <DeleteButton id={post.id} />
             </div>

--- a/app/places/index/page.tsx
+++ b/app/places/index/page.tsx
@@ -7,6 +7,7 @@ type PostWithLocation = {
   title: string;
   explanation: string;
   address: string;
+  userId: string | null
   latitude: number;
   longitude: number;
   createdAt: Date;

--- a/app/places/new/page.tsx
+++ b/app/places/new/page.tsx
@@ -6,6 +6,7 @@ type PostWithLocation = {
   title: string;
   explanation: string;
   address: string;
+  userId: string | null;
   latitude: number;
   longitude: number;
   createdAt: Date;

--- a/prisma/migrations/20260623152952_add_place_author/migration.sql
+++ b/prisma/migrations/20260623152952_add_place_author/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Sanctuaries" ADD COLUMN     "userId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Sanctuaries" ADD CONSTRAINT "Sanctuaries_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   updatedAt     DateTime @updatedAt
   accounts      Account[]
   sessions      Session[]
+  sanctuaries   Sanctuaries[]
 }
 
 model VerificationToken {
@@ -61,6 +62,8 @@ model VerificationToken {
 
 model Sanctuaries {
   id           String   @id @default(cuid())
+  userId       String?
+  user         User? @relation(fields: [userId], references: [id])
   title        String
   address      String
   explanation  String


### PR DESCRIPTION
詳細画面に投稿者名を表示するため、UserとSanctuariesを1対多で関連付けました。
投稿時にログイン中のユーザーIDを保存し、詳細画面では関連するユーザー情報を取得して、投稿者名を表示するようにしました。
