### PR TITLE
"feat: 投稿・編集フォームにバリデーションを追加"

### DIFF
--- a/app/places/[placeId]/edit/_components/EditPlaceForm.tsx
+++ b/app/places/[placeId]/edit/_components/EditPlaceForm.tsx
@@ -20,7 +20,11 @@ export default function EditPlaceForm(props: EditPlaceFormProps) {
     explanation: string;
     address: string;
   };
-  const { register, handleSubmit } = useForm<FormValues>({});
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({});
   const submitEditPlace = async (data: FormValues): Promise<void> => {
     try {
       const res = await fetch("/api/places", {
@@ -48,23 +52,48 @@ export default function EditPlaceForm(props: EditPlaceFormProps) {
       <h1 className="text-2xl font-bold mb-4">聖地編集フォーム</h1>
       <p className="text-gray-800">タイトル</p>
       <input
-        {...register("title")}
+        {...register("title", {
+          required: "タイトルを入力してください",
+          maxLength: {
+            value: 50,
+            message: "タイトルは50文字以内で入力してください",
+          },
+        })}
         className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3"
         defaultValue={props.post.title}
       />
+      {errors.title && (
+        <p className="text-red-500 text-sm mb-3">{errors.title.message}</p>
+      )}
       <p className="text-gray-800">説明</p>
       <textarea
-        {...register("explanation")}
+        {...register("explanation", {
+          required: "説明を入力してください",
+          maxLength: {
+            value: 500,
+            message: "説明は500文字以内で入力してください",
+          },
+        })}
         className="text-black bg-blue-100 h-[100px] w-full rounded p-2 mt-1 mb-3"
         defaultValue={props.post.explanation}
       />
+      {errors.explanation && (
+        <p className="text-red-500 text-sm mb-3">
+          {errors.explanation.message}
+        </p>
+      )}
       <p className="text-gray-800">住所</p>
       <input
-        {...register("address")}
+        {...register("address", {
+          required: "住所を入力してください",
+        })}
         type="text"
         className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3"
         defaultValue={props.post.address}
       />
+      {errors.address && (
+        <p className="text-red-500 text-sm mb-3">{errors.address.message}</p>
+      )}
       <p>
         <UpdateButton />
       </p>

--- a/app/places/new/_components/NewPlaceForm.tsx
+++ b/app/places/new/_components/NewPlaceForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import PostButton from "@/app/_components/PostButton";
+
 type FormValues = {
   title: string;
   explanation: string;
@@ -21,7 +22,12 @@ type ClickedLocation = {
 
 export default function NewPlaceForm({ selectedLocation }: NewPlaceFormProps) {
   const router = useRouter();
-  const { register, handleSubmit, setValue } = useForm<FormValues>({});
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({});
   useEffect(() => {
     if (selectedLocation) {
       const address = selectedLocation.address;
@@ -62,20 +68,45 @@ export default function NewPlaceForm({ selectedLocation }: NewPlaceFormProps) {
       </h1>
       <p className="text-gray-800">タイトル</p>
       <input
-        {...register("title")}
+        {...register("title", {
+          required: "タイトルを入力してください",
+          maxLength: {
+            value: 50,
+            message: "タイトルは50文字以内で入力してください",
+          },
+        })}
         className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3"
       />
+      {errors.title && (
+        <p className="text-red-500 text-sm mb-3">{errors.title.message}</p>
+      )}
       <p className="text-gray-800">説明</p>
       <textarea
-        {...register("explanation")}
+        {...register("explanation", {
+          required: "説明を入力してください",
+          maxLength: {
+            value: 500,
+            message: "説明は500文字以内で入力してください",
+          },
+        })}
         className="text-black bg-blue-100 h-[100px] w-full rounded p-2 mt-1 mb-3"
       />
+      {errors.explanation && (
+        <p className="text-red-500 text-sm mb-3">
+          {errors.explanation.message}
+        </p>
+      )}
       <p className="text-gray-800">住所</p>
       <input
         type="text"
-        {...register("address")}
+        {...register("address", {
+          required: "住所を入力してください",
+        })}
         className="text-black bg-blue-100 w-full rounded p-2 mt-1 mb-3"
       />
+      {errors.address && (
+        <p className="text-red-500 text-sm mb-3">{errors.address.message}</p>
+      )}
       <p>
         <PostButton />
       </p>


### PR DESCRIPTION
投稿フォームと編集フォームにバリデーションを追加しました。

タイトル・説明・住所が空欄の場合は、投稿・更新できないようにしています。また、タイトルは50文字以内、説明は500文字以内の文字数制限を設けました。
