### PR TITLE
style: クリック可能な要素にカーソルポインターを追加

### DIFF
--- a/app/_components/DeleteButton.tsx
+++ b/app/_components/DeleteButton.tsx
@@ -26,7 +26,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
     <button
       type="button"
       onClick={() => submitDeletePlace()}
-      className="rounded bg-red-500 px-4 py-2 text-white"
+      className="rounded bg-red-500 px-4 py-2 text-white cursor-pointer"
     >
       削除
     </button>

--- a/app/_components/EditButton.tsx
+++ b/app/_components/EditButton.tsx
@@ -12,7 +12,7 @@ export default function EditButton(props: EditButtonProps) {
     <button
       type="button"
       onClick={() => router.push(props.href)}
-      className="rounded bg-gray-300 px-4 py-2 text-gray-800"
+      className="rounded bg-gray-300 px-4 py-2 text-gray-800 cursor-pointer"
     >
       編集
     </button>

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -46,6 +46,7 @@ export default function Footer() {
               href="https://docs.google.com/forms/d/e/1FAIpQLSfhbbVHSebxNxt1uq_hDArf6wAcC-7dvaB_wUdftozGFwyZGg/viewform?usp=publish-editor"
               target="_blank"
               rel="noopener noreferrer"
+              className="text-gray-200 hover:underline"
             >
               お問い合わせ
             </a>

--- a/app/_components/PostButton.tsx
+++ b/app/_components/PostButton.tsx
@@ -1,6 +1,6 @@
 export default function PostButton() {
   return (
-    <button type="submit" className="rounded bg-blue-500 px-4 py-2 text-white">
+    <button type="submit" className="rounded bg-blue-500 px-4 py-2 text-white cursor-pointer">
       投稿
     </button>
   );

--- a/app/_components/UpdateButton.tsx
+++ b/app/_components/UpdateButton.tsx
@@ -1,6 +1,6 @@
 export default function UpdateButton() {
   return (
-    <button type="submit" className="rounded bg-blue-500 px-4 py-2 text-white">
+    <button type="submit" className="rounded bg-blue-500 px-4 py-2 text-white cursor-pointer">
       変更を保存
     </button>
   );

--- a/app/places/index/_components/PlacesIndexContainer.tsx
+++ b/app/places/index/_components/PlacesIndexContainer.tsx
@@ -97,7 +97,7 @@ export default function PlacesIndexContainer({
           <div>
             <div className="flex-col gap-2 mb-4 items-start">
               <button
-                className="bg-blue-500 rounded-full text-white py-2 px-4"
+                className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer"
                 onClick={handleGetCurrentLocation}
               >
                 現在地を取得

--- a/app/places/new/_components/NewPlaceContainer.tsx
+++ b/app/places/new/_components/NewPlaceContainer.tsx
@@ -62,7 +62,9 @@ export default function NewPlaceContainer({ posts }: NewPlaceContainerProps) {
             <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10">
               <div className="bg-white text-black rounded-2xl p-6 shadow-xl w-[90%] max-w-[400px] max-h-[90%] overflow-y-auto">
                 <NewPlaceForm selectedLocation={selectedLocation} />
-                <button onClick={closeModal}>閉じる</button>
+                <button onClick={closeModal} className="cursor-pointer">
+                  閉じる
+                </button>
               </div>
             </div>
           )}


### PR DESCRIPTION
- クリック可能なボタンや操作対象に cursor-pointer を追加しました。
- マウスホバー時に指マークを表示し、操作できる要素であることが分かりやすくなるようにしました。