### PR TITLE
feat: 場所一覧にページネーションを追加

### DIFF
--- a/app/places/index/_components/PlacesIndexContainer.tsx
+++ b/app/places/index/_components/PlacesIndexContainer.tsx
@@ -58,12 +58,14 @@ export default function PlacesIndexContainer({
     useState<CurrentLocation | null>(null);
 
   const [sortOrder, setSortOrder] = useState("新しい順");
+  const [page, setPage] = useState(1);
   const handleGetCurrentLocation = () => {
     navigator.geolocation.getCurrentPosition((position) => {
       setCurrentLocation({
         latitude: position.coords.latitude,
         longitude: position.coords.longitude,
       });
+      setPage(1);
     });
   };
   const sortedPosts = [...posts];
@@ -93,6 +95,11 @@ export default function PlacesIndexContainer({
     };
     sortedPosts.sort(compareByDate);
   }
+  const PER_PAGE = 6;
+  const startIndex = (page - 1) * PER_PAGE;
+  const endIndex = startIndex + PER_PAGE;
+  const currentPosts = sortedPosts.slice(startIndex, endIndex);
+  const totalPages = Math.ceil(sortedPosts.length / PER_PAGE);
   return (
     <div className="p-4 flex flex-col">
       <div className="flex items-center gap-2 font-bold text-2xl mb-4">
@@ -119,23 +126,35 @@ export default function PlacesIndexContainer({
               <button
                 className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer"
                 onClick={handleGetCurrentLocation}
+                  
               >
                 現在地を取得
               </button>
-              <button className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer ml-2" onClick={() => setSortOrder("新しい順")}>
-  新しい順
-</button>
+              <button
+                className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer ml-2"
+                onClick={() => {
+                  setSortOrder("新しい順");
+                  setPage(1);
+                }}
+              >
+                新しい順
+              </button>
 
-<button className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer ml-2" onClick={() => setSortOrder("古い順")}>
-  古い順
-</button>
+              <button
+                className="bg-blue-500 rounded-full text-white py-2 px-4 cursor-pointer ml-2"
+                onClick={() => {
+                  setSortOrder("古い順");
+                  setPage(1);
+                }}
+              >
+                古い順
+              </button>
             </div>
             {currentLocation && <p>現在地を取得しました</p>}
-            
           </div>
-          
+
           <div className="overflow-y-auto h-[600px]">
-            {sortedPosts.map((post) => {
+            {currentPosts.map((post) => {
               return (
                 <div className="py-2" key={post.id}>
                   <div className="bg-white p-4 md:p-6 rounded-lg shadow-md">
@@ -166,6 +185,32 @@ export default function PlacesIndexContainer({
                 </div>
               );
             })}
+          </div>
+          <div className="flex justify-center gap-4">
+            <button className="rounded bg-gray-800 px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-40" onClick={() => setPage(page - 1)} disabled={page === 1}>
+              前へ
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(
+    (pageNumber) => (
+      <button className={
+  page === pageNumber
+    ? "rounded bg-blue-500 px-3 py-2 text-white"
+    : "rounded bg-gray-200 px-3 py-2"
+}
+        key={pageNumber}
+        onClick={() => setPage(pageNumber)}
+      >
+        {pageNumber}
+      </button>
+    ),
+  )}
+            <button
+              className="rounded bg-gray-800 px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-40"
+              onClick={() => setPage(page + 1)}
+              disabled={page >= totalPages}
+            >
+              次へ
+            </button>
           </div>
         </div>
         <div className="md:w-3/5 md:h-[600px] relative rounded-lg overflow-hidden border w-full order-1 md:order-2 h-[300px]">


### PR DESCRIPTION
場所一覧の投稿を1ページあたり6件ずつ表示するページネーション機能を追加しました。
現在のページ番号をuseStateで管理し、ページ番号に応じて表示開始位置と終了位置を計算しています。sliceを使用して、並び替え後の投稿一覧から現在のページに必要な投稿だけを取り出して表示しています。
また、「前へ」「次へ」ボタンとページ番号ボタンを設置しました。1ページ目では「前へ」、最終ページでは「次へ」を押せないようにしています。並び順や現在地順に切り替えた場合は、1ページ目に戻るようにしました。
