### PR TITLE
fix: 現在地取得後も地図をマウスで動かせるようにする

### DIFF
--- a/app/places/_components/PlacesMap.tsx
+++ b/app/places/_components/PlacesMap.tsx
@@ -4,8 +4,9 @@ import {
   Map,
   Marker,
   InfoWindow,
+  useMap
 } from "@vis.gl/react-google-maps";
-import { useState } from "react";
+import { useState,useEffect  } from "react";
 type Post = {
   id: string;
   title: string;
@@ -31,6 +32,10 @@ type CurrentLocation = {
   longitude: number;
 };
 
+type CurrentLocationMoveProps = {
+  currentLocation?: CurrentLocation | null;
+};
+
 export default function PlacesMap({
   posts,
   onLocationSelect,
@@ -44,7 +49,6 @@ export default function PlacesMap({
   if (!mapKey) {
     return <p>APIキーがありません</p>;
   }
-
   const mapPosts = posts.filter((post) => {
     return post.latitude != null && post.longitude != null;
   });
@@ -61,6 +65,25 @@ export default function PlacesMap({
     const data = await res.json();
     setSearchedLocation(data);
   };
+
+ function CurrentLocationMove({
+  currentLocation,
+}: CurrentLocationMoveProps) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map || !currentLocation) return;
+
+    const latLng = {
+      lat: currentLocation.latitude,
+      lng: currentLocation.longitude,
+    };
+
+    map.panTo(latLng);
+  }, [map, currentLocation]);
+
+  return null;
+}
   return (
     <div className="w-full h-full relative">
       <APIProvider apiKey={mapKey}>
@@ -81,11 +104,6 @@ export default function PlacesMap({
                   lat: searchedLocation.latitude,
                   lng: searchedLocation.longitude,
                 }
-              : currentLocation
-                ? {
-                    lat: currentLocation.latitude,
-                    lng: currentLocation.longitude,
-                  }
                 : undefined
           }
           defaultZoom={10}
@@ -142,6 +160,7 @@ export default function PlacesMap({
               </div>
             </InfoWindow>
           )}
+          <CurrentLocationMove currentLocation={currentLocation} />
         </Map>
       </APIProvider>
     </div>


### PR DESCRIPTION
- これまで、現在地ボタンを押して現在地を取得した後、地図上でマウス操作による移動ができない状態でした。そのため、現在地取得後は一度だけ現在地へ地図を移動し、その後は自由に地図を操作できるよう修正しました。
